### PR TITLE
Void purchase

### DIFF
--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Omnipay\Payflow\Message;
+
+/**
+ * Payflow Void Request
+ */
+class VoidRequest extends AuthorizeRequest
+{
+    protected $action = 'V';
+    public function getData()
+    {
+        $this->validate('transactionReference');
+
+        $data = $this->getBaseData();
+        $data['ORIGID'] = $this->getTransactionReference();
+
+        return $data;
+    }
+
+}

--- a/src/ProGateway.php
+++ b/src/ProGateway.php
@@ -90,4 +90,9 @@ class ProGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\Payflow\Message\RefundRequest', $parameters);
     }
+
+    public function void(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Payflow\Message\VoidRequest', $parameters);
+    }
 }

--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -95,4 +95,19 @@ class ProGatewayTest extends GatewayTestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertEquals('A10A6AE7042E', $response->getTransactionReference());
     }
+
+    public function testVoid()
+    {
+        $options = array(
+            'transactionReference' => 'abc123',
+        );
+
+        $this->setMockHttpResponse('PurchaseSuccess.txt');
+
+        $response = $this->gateway->void($options)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals('A10A6AE7042E', $response->getTransactionReference());
+    }
+
 }


### PR DESCRIPTION
Omnipay supports a void transaction (https://developer.paypal.com/docs/classic/payflow/integration-guide/#submitting-void-transactions) which just requires the original transaction ID as a parameter. I've added a message for that and a test.