### PR TITLE
Add PONUM specification support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
 
 before_script:
   - composer install -n --dev --prefer-source

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -188,6 +188,16 @@ class AuthorizeRequest extends AbstractRequest
         return $this->setParameter('orderid', $value);
     }
 
+    public function setPoNum($value)
+    {
+        return $this->setParameter('ponum', $value);
+    }
+
+    public function getPoNum()
+    {
+        return $this->getParameter('ponum');
+    }
+
     /**
      * @deprecated
      */
@@ -245,6 +255,7 @@ class AuthorizeRequest extends AbstractRequest
         $data['COMMENT1'] = $this->getDescription();
         $data['COMMENT2'] = $this->getComment2();
         $data['ORDERID'] = $this->getOrderId();
+        $data['PONUM'] = $this->getPoNum();
 
         $data['BILLTOEMAIL'] = $this->getCard()->getEmail();
         $data['BILLTOPHONENUM'] = $this->getCard()->getBillingPhone();

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -31,6 +31,12 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('bar', $this->request->getComment2());
     }
 
+    public function testPoNum()
+    {
+        $this->assertSame($this->request, $this->request->setPoNum('abcdefghijklmnopqrstuvwxy'));
+        $this->assertSame('abcdefghijklmnopqrstuvwxy', $this->request->getPoNum());
+    }
+
     public function testGetData()
     {
         $card = $this->getValidCard();
@@ -41,6 +47,7 @@ class AuthorizeRequestTest extends TestCase
                 'comment2' => 'more things',
                 'card' => $card,
                 'transactionId' => '123',
+                'ponum' => 'abcdefghijklmnopqrstuvwxy',
             )
         );
 
@@ -51,6 +58,7 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('things', $data['COMMENT1']);
         $this->assertSame('more things', $data['COMMENT2']);
         $this->assertSame('123', $data['ORDERID']);
+        $this->assertSame('abcdefghijklmnopqrstuvwxy', $data['PONUM']);
     }
 
     public function testEncodeData()

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -46,7 +46,7 @@ class AuthorizeRequestTest extends TestCase
                 'description' => 'things',
                 'comment2' => 'more things',
                 'card' => $card,
-                'transactionId' => '123',
+                'orderid' => '123',
                 'ponum' => 'abcdefghijklmnopqrstuvwxy',
             )
         );


### PR DESCRIPTION
Need support to specify the PONUM key on the Payflow request, part of the optional fields.

https://developer.paypal.com/docs/classic/payflow/integration-guide/#payflow-sdk

"PONUM; (Optional) Purchase order number / merchant-related data.
Character length and limitations: 25 alphanumeric characters, provides best rate when used"
