### PR TITLE
Update test card number in doc blocks to new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [Omnipay](https://github.com/thephpleague/omnipay) is a framework agnostic, multi-gateway payment
 processing library for PHP 5.3+. This package implements [Payflow](https://developer.paypal.com/docs/classic/products/payflow-gateway/) support for Omnipay.
 
+This package is tested and works with PHP 7 and 7.1.
+
 ## Installation
 
 Omnipay is installed via [Composer](http://getcomposer.org/). To install, simply add it

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -28,7 +28,7 @@ use Omnipay\Common\Message\AbstractRequest;
  * $card = new CreditCard(array(
  *             'firstName'    => 'Example',
  *             'lastName'     => 'Customer',
- *             'number'       => '4242424242424242',
+ *             'number'       => '4111111111111111',
  *             'expiryMonth'  => '01',
  *             'expiryYear'   => '2020',
  *             'cvv'          => '123',

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -26,7 +26,7 @@ namespace Omnipay\Payflow\Message;
  * $card = new CreditCard(array(
  *             'firstName'    => 'Example',
  *             'lastName'     => 'Customer',
- *             'number'       => '4242424242424242',
+ *             'number'       => '4111111111111111',
  *             'expiryMonth'  => '01',
  *             'expiryYear'   => '2020',
  *             'cvv'          => '123',

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -26,7 +26,7 @@ namespace Omnipay\Payflow\Message;
  * $card = new CreditCard(array(
  *             'firstName'    => 'Example',
  *             'lastName'     => 'Customer',
- *             'number'       => '4242424242424242',
+ *             'number'       => '4111111111111111',
  *             'expiryMonth'  => '01',
  *             'expiryYear'   => '2020',
  *             'cvv'          => '123',

--- a/src/Message/FetchTransactionRequest.php
+++ b/src/Message/FetchTransactionRequest.php
@@ -26,7 +26,7 @@ namespace Omnipay\Payflow\Message;
  * $card = new CreditCard(array(
  *             'firstName'    => 'Example',
  *             'lastName'     => 'Customer',
- *             'number'       => '4242424242424242',
+ *             'number'       => '4111111111111111',
  *             'expiryMonth'  => '01',
  *             'expiryYear'   => '2020',
  *             'cvv'          => '123',

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -26,7 +26,7 @@ namespace Omnipay\Payflow\Message;
  * $card = new CreditCard(array(
  *             'firstName'    => 'Example',
  *             'lastName'     => 'Customer',
- *             'number'       => '4242424242424242',
+ *             'number'       => '4111111111111111',
  *             'expiryMonth'  => '01',
  *             'expiryYear'   => '2020',
  *             'cvv'          => '123',

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -26,7 +26,7 @@ namespace Omnipay\Payflow\Message;
  * $card = new CreditCard(array(
  *             'firstName'    => 'Example',
  *             'lastName'     => 'Customer',
- *             'number'       => '4242424242424242',
+ *             'number'       => '4111111111111111',
  *             'expiryMonth'  => '01',
  *             'expiryYear'   => '2020',
  *             'cvv'          => '123',

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -26,7 +26,7 @@ namespace Omnipay\Payflow\Message;
  * $card = new CreditCard(array(
  *             'firstName'    => 'Example',
  *             'lastName'     => 'Customer',
- *             'number'       => '4242424242424242',
+ *             'number'       => '4111111111111111',
  *             'expiryMonth'  => '01',
  *             'expiryYear'   => '2020',
  *             'cvv'          => '123',

--- a/src/ProGateway.php
+++ b/src/ProGateway.php
@@ -69,7 +69,7 @@ use Omnipay\Common\AbstractGateway;
  * $card = new CreditCard(array(
  *             'firstName'    => 'Example',
  *             'lastName'     => 'Customer',
- *             'number'       => '4242424242424242',
+ *             'number'       => '4111111111111111',
  *             'expiryMonth'  => '01',
  *             'expiryYear'   => '2020',
  *             'cvv'          => '123',


### PR DESCRIPTION
This updates the credit card number used in tests based on the value in the new docs.

https://developer.paypal.com/docs/classic/payflow/integration-guide/#paypal-credit-card-numbers-for-testing