### PR TITLE
Implement getCardReference for Authorization and CreateCard responses

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -61,4 +61,11 @@ class Response extends AbstractResponse
     {
         return isset($this->data['RESPMSG']) ? $this->data['RESPMSG'] : null;
     }
+
+    public function getCardReference()
+    {
+        return $this->request instanceof AuthorizeRequest || $this->request instanceof CreateCardRequest
+            ? $this->getTransactionReference()
+            : null;
+    }
 }

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Payflow\Message;
 
+use Mockery as m;
 use Omnipay\Tests\TestCase;
 
 class ResponseTest extends TestCase
@@ -64,5 +65,21 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertSame('User authentication failed', $response->getMessage());
+    }
+
+    public function testCreateCard()
+    {
+        $httpResponse = $this->getMockHttpResponse('CreateCardSuccess.txt');
+
+        /* @var \Omnipay\Payflow\Message\CreateCardRequest $request */
+        $request = m::mock('\Omnipay\Payflow\Message\CreateCardRequest');
+
+        $response = new Response($request, $httpResponse->getBody());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertEquals('A10AA633AB30', $response->getCardReference());
+        $this->assertEquals('Approved', $response->getMessage());
+        $this->assertEquals(0, $response->getCode());
     }
 }

--- a/tests/Mock/CreateCardSuccess.txt
+++ b/tests/Mock/CreateCardSuccess.txt
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Connection: close
+Server: VPS-3.033.00
+Date: Tue, 17 Aug 2017 02:34:58 GMT
+Content-type: text/namevalue
+Content-length: 44
+
+RESULT=0&PNREF=A10AA633AB30&RESPMSG=Approved


### PR DESCRIPTION
- proposal in response to GitHub issue #10
- the interface does not have this method, nor is there a distinct value for it in the Payflow response
- Payflow docs: "TRXTYPE=L can be used to upload credit card data, easing PCI compliance. You can store the resulting PNREF locally for use in performing reference transactions."
