### PR TITLE
Make comments transmit for all transaction types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -222,6 +222,12 @@ class AuthorizeRequest extends AbstractRequest
         $data['PWD'] = $this->getPassword();
         $data['VENDOR'] = $this->getVendor();
         $data['PARTNER'] = $this->getPartner();
+        if ($this->getDescription()) {
+            $data['COMMENT1'] = $this->getDescription();
+        }
+        if ($this->getComment2()) {
+            $data['COMMENT2'] = $this->getComment2();
+        }
 
         return $data;
     }
@@ -252,8 +258,6 @@ class AuthorizeRequest extends AbstractRequest
         $data['TENDER'] = 'C';
         $data['AMT'] = $this->getAmount();
         $data['CURRENCY'] = $this->getCurrency();
-        $data['COMMENT1'] = $this->getDescription();
-        $data['COMMENT2'] = $this->getComment2();
         $data['ORDERID'] = $this->getOrderId();
         $data['PONUM'] = $this->getPoNum();
 

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -1,0 +1,65 @@
+<?php namespace Omnipay\Payflow\Message;
+
+use Omnipay\Tests\TestCase;
+
+class CaptureRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new CaptureRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'amount'                   => '10.00',
+                'transactionReference'     => 'ABC123',
+            )
+        );
+    }
+
+    public function testComment1()
+    {
+        // comment1 is alias for description
+        $this->assertSame($this->request, $this->request->setComment1('foo'));
+        $this->assertSame('foo', $this->request->getComment1());
+        $this->assertSame('foo', $this->request->getDescription());
+    }
+
+    public function testComment2()
+    {
+        $this->assertSame($this->request, $this->request->setComment2('bar'));
+        $this->assertSame('bar', $this->request->getComment2());
+    }
+
+    public function testGetData()
+    {
+        $this->request->initialize(
+            array(
+                'amount' => '12.00',
+                'description' => 'things',
+                'comment2' => 'more things',
+                'transactionReference' => 'ABC123',
+            )
+        );
+
+        $data = $this->request->getData();
+
+        $this->assertSame('D', $data['TRXTYPE']);
+        $this->assertSame('12.00', $data['AMT']);
+        $this->assertSame('ABC123', $data['ORIGID']);
+        $this->assertSame('things', $data['COMMENT1']);
+        $this->assertSame('more things', $data['COMMENT2']);
+    }
+
+    public function testDoesntSendEmptyComments()
+    {
+        $this->request->initialize(
+            array(
+                'amount' => '12.00',
+                'transactionReference' => 'ABC123',
+            )
+        );
+
+        $data = $this->request->getData();
+        $this->assertArrayNotHasKey('COMMENT1', $data);
+        $this->assertArrayNotHasKey('COMMENT2', $data);
+    }
+}


### PR DESCRIPTION
Payflow allows comments on all transaction types, but the current code only sends them on AuthorizeRequests. (Most of AuthorizeRequests subclasses override `getData()` where the comment fields are populated.)

This commit moves the comment fields into the `getBaseData()` function, which all the subclasses use so all the transactions will pass those fields if present.