### PR TITLE
Implement reference purchases

### DIFF
--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -71,6 +71,21 @@ class ProGatewayTest extends GatewayTestCase
         $this->assertEquals('A10A6AE7042E', $response->getTransactionReference());
     }
 
+    public function testReferencePurchaseSuccess()
+    {
+        $options = array(
+            'amount' => '10.00',
+            'transactionReference' => 'abc123',
+        );
+
+        $this->setMockHttpResponse('PurchaseSuccess.txt');
+
+        $response = $this->gateway->purchase($options)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals('A10A6AE7042E', $response->getTransactionReference());
+    }
+
     public function testPurchaseError()
     {
         $this->setMockHttpResponse('PurchaseFailure.txt');


### PR DESCRIPTION
- This is a key feature of the payflow api,
- Is required for tokenization and multi-part shipping
- Is described in [Submitting Reference Transactions - Tokenization]( https://developer.paypal.com/docs/classic/payflow/integration-guide/#submitting-reference-transactions---tokenization)
- Test added
- Updated PurchaseRequest Docs