### PR TITLE
More flexible use of transactionReference with Purchase

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -81,12 +81,8 @@ class PurchaseRequest extends AuthorizeRequest
 
     public function getReferenceSaleData()
     {
-        $this->validate('transactionReference', 'amount');
-
-        $data = $this->getBaseData();
-        $data['AMT'] = $this->getAmount();
+        $this->validate('transactionReference');
         $data['ORIGID'] = $this->getTransactionReference();
-        $data['TENDER'] = 'C';
 
         return $data;
     }


### PR DESCRIPTION
- AMT and TENDER, and baseData() are already set in parent::getData() removed in 
88e4a2b