### PR TITLE
Use CardReference for reference purchases

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -261,8 +261,10 @@ class AuthorizeRequest extends AbstractRequest
         $data['ORDERID'] = $this->getOrderId();
         $data['PONUM'] = $this->getPoNum();
 
-        $data['BILLTOEMAIL'] = $this->getCard()->getEmail();
-        $data['BILLTOPHONENUM'] = $this->getCard()->getBillingPhone();
+        if ($this->getCard()) {
+            $data['BILLTOEMAIL'] = $this->getCard()->getEmail();
+            $data['BILLTOPHONENUM'] = $this->getCard()->getBillingPhone();
+        }
 
         $items = $this->getItems();
         if (!empty($items)) {

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -36,8 +36,8 @@ namespace Omnipay\Payflow\Message;
  * // $reference_id can be the transaction reference from a previous authorization, credit, capture, sale, voice auth,
  * // or void.
  * $transaction = $gateway->purchase(array(
- *     'amount'                   => '10.00',
- *     'transactionReference'     => $reference_id,
+ *     'amount'        => '10.00',
+ *     'cardReference' => $reference_id,
  * ));
  *
  * // 2. Sale (with card data) example:
@@ -69,25 +69,4 @@ namespace Omnipay\Payflow\Message;
 class PurchaseRequest extends AuthorizeRequest
 {
     protected $action = 'S';
-
-    public function getData()
-    {
-        if ($this->parameters->get('transactionReference')) {
-            return $this->getReferenceSaleData();
-        }
-
-        return parent::getData();
-    }
-
-    public function getReferenceSaleData()
-    {
-        $this->validate('transactionReference', 'amount');
-
-        $data = $this->getBaseData();
-        $data['AMT'] = $this->getAmount();
-        $data['ORIGID'] = $this->getTransactionReference();
-        $data['TENDER'] = 'C';
-
-        return $data;
-    }
 }

--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -75,7 +75,7 @@ class ProGatewayTest extends GatewayTestCase
     {
         $options = array(
             'amount' => '10.00',
-            'transactionReference' => 'abc123',
+            'cardReference' => 'abc123',
         );
 
         $this->setMockHttpResponse('PurchaseSuccess.txt');


### PR DESCRIPTION
- Use of transactionReference for purchase creates cross-driver
compatibility issues for purchase (see issue #21), preventing it from being
consistently used across all reference requests (sale, refund, void).

- cardReference was implemented but broken due to a dependency on
the purchase request having an embedded card object.

- the breaking dependency is now optional, simplifying reference
purchase implementation.

Tests updated.