### PR TITLE
 Send CVV2 with card reference transactions

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -239,6 +239,9 @@ class AuthorizeRequest extends AbstractRequest
 
         if ($this->getCardReference()) {
             $data['ORIGID'] = $this->getCardReference();
+            if ($this->getCard()) {
+                $data['CVV2'] = $this->getCard()->getCvv();
+            }
         } else {
             $this->validate('card');
             $this->getCard()->validate();

--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -86,6 +86,26 @@ class ProGatewayTest extends GatewayTestCase
         $this->assertEquals('A10A6AE7042E', $response->getTransactionReference());
     }
 
+    public function testReferencePurchaseWithCvvSuccess()
+    {
+        $options = array(
+            'amount' => '10.00',
+            'cardReference' => 'abc123',
+            'card' => new CreditCard(array(
+                'cvv' => '123',
+            )),
+        );
+
+        $this->setMockHttpResponse('PurchaseSuccess.txt');
+
+        $request = $this->gateway->purchase($options);
+        $response = $request->send();
+
+        $this->assertArrayHasKey('CVV2', $request->getData());
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals('A10A6AE7042E', $response->getTransactionReference());
+    }
+
     public function testPurchaseError()
     {
         $this->setMockHttpResponse('PurchaseFailure.txt');


### PR DESCRIPTION
If the CVV2 is available, it should be sent with the transaction so Payflow can check it if it was not done before.