### PR TITLE
Leave php-http implementation choice to the user

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr-4": { "Omnipay\\Payflow\\" : "src/" }
     },
     "require": {
-        "league/omnipay": "^3.0",
+        "omnipay/common": "^3.0",
         "squizlabs/php_codesniffer": "^3"
     },
     "require-dev": {


### PR DESCRIPTION
Other omnipay 3 drivers require `omnipay/common`, because requiring `league/omnipay` forces you to use guzzle v6